### PR TITLE
Npm dependencies update

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "ramda-loader",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -36,9 +36,9 @@
       }
     },
     "acorn": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
@@ -312,9 +312,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.18.tgz",
-      "integrity": "sha1-yLmFdImOiRTp2N50uUdWSp/pKa8="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+      "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
     },
     "async": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "test"
   },
   "dependencies": {
-    "acorn": "^3.1.0",
-    "ast-types": "^0.8.16",
+    "acorn": "^5.2.1",
+    "ast-types": "^0.10.1",
     "escodegen": "^1.8.0",
     "estraverse": "^4.2.0",
     "loader-utils": "^1.1.0",


### PR DESCRIPTION
I've noticed the **DUMCONSTANTIN** tag with **out of date**. So I decided to open another PR.

Ran a few test locally, seems to be nonbreaking change.

This PR contains **acorn** and **ast-types** version updates.
